### PR TITLE
Removed the wrapper around `call_query()`.

### DIFF
--- a/compiler/rustc_macros/src/query.rs
+++ b/compiler/rustc_macros/src/query.rs
@@ -500,7 +500,7 @@ pub fn rustc_queries(input: TokenStream) -> TokenStream {
                 ::rustc_middle::dep_graph::DepKind::#name => {
                     if <#arg as DepNodeParams<TyCtxt<'_>>>::can_reconstruct_query_key() {
                         if let Some(key) = <#arg as DepNodeParams<TyCtxt<'_>>>::recover($tcx, $dep_node) {
-                            crate::ty::query::queries::#name::query(
+                            call_query::<crate::ty::query::queries::#name<'_>, _>(
                                 $tcx,
                                 DUMMY_SP,
                                 key,

--- a/compiler/rustc_middle/src/ty/query/plumbing.rs
+++ b/compiler/rustc_middle/src/ty/query/plumbing.rs
@@ -394,19 +394,6 @@ macro_rules! define_queries_inner {
             ) -> Self::Value {
                 handle_cycle_error!([$($modifiers)*][tcx, error])
             }
-        }
-
-        impl queries::$name<$tcx> {
-            $(#[$attr])*
-            #[inline(always)]
-            pub fn query(
-                tcx: TyCtxt<$tcx>,
-                span: Span,
-                key: query_keys::$name<$tcx>,
-                caller: QueryCaller<DepKind>,
-            ) -> Option<<queries::$name<$tcx> as QueryConfig<TyCtxt<$tcx>>>::Stored> {
-                call_query::<queries::$name<'_>, _>(tcx, span, key, caller)
-            }
         })*
 
         #[derive(Copy, Clone)]
@@ -418,7 +405,7 @@ macro_rules! define_queries_inner {
             $($(#[$attr])*
             #[inline(always)]
             pub fn $name(self, key: query_helper_param_ty!($($K)*)) {
-                queries::$name::query(
+                call_query::<queries::$name<'_>, _>(
                     self.tcx,
                     DUMMY_SP,
                     key.into_query_param(),
@@ -506,7 +493,7 @@ macro_rules! define_queries_inner {
             pub fn $name(self, key: query_helper_param_ty!($($K)*))
                 -> <queries::$name<$tcx> as QueryConfig<TyCtxt<$tcx>>>::Stored
             {
-                let ret = queries::$name::query(
+                let ret = call_query::<queries::$name<'_>, _>(
                     self.tcx,
                     self.span,
                     key.into_query_param(),


### PR DESCRIPTION
Small change to rust-lang/rust#77833.